### PR TITLE
Add Manta dataset testing service integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Rockfish API Configuration
 ROCKFISH_API_KEY=your_api_key_here
-ROCKFISH_BASE_URL=https://api.rockfish.ai
+ROCKFISH_BASE_URL=https://sunset-beach.rockfish.ai
+
+# Manta Service Configuration (optional)
+# Uncomment the line below to enable Manta tools for dataset testing and pattern injection
+# MANTA_BASE_URL=https://manta.sunset-beach.rockfish.ai

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ rockfish-mcp
 The application requires these environment variables:
 - `ROCKFISH_API_KEY`: Your Rockfish API key (required)
 - `ROCKFISH_BASE_URL`: Base URL for Rockfish API (defaults to https://api.rockfish.ai)
+- `MANTA_BASE_URL`: Base URL for Manta service (optional - Manta tools only appear if this is set)
 
 Create a `.env` file with these variables for local development:
 ```bash
@@ -35,54 +36,93 @@ cp .env.example .env
 
 ## Architecture Overview
 
-This is an MCP (Model Context Protocol) server that provides AI assistants access to the Rockfish machine learning platform API. The architecture consists of two main components in a simple, focused structure.
+This is an MCP (Model Context Protocol) server that provides AI assistants access to the Rockfish machine learning platform API and the Manta dataset testing service. The architecture consists of three main components in a simple, focused structure.
 
 ### Project Structure
 ```
 src/rockfish_mcp/
 ├── __init__.py
-├── server.py      # MCP server with tool definitions and routing
-└── client.py      # HTTP client for Rockfish API calls
+├── server.py       # MCP server with tool definitions and routing
+├── client.py       # HTTP client for Rockfish API calls
+└── manta_client.py # HTTP client for Manta service calls
 ```
 
 ### Core Components
 
 **Server (`server.py`)**: The main MCP server that:
-- Defines 22 tools across 6 resource categories (Databases, Worker Sets, Workflows, Models, Projects, Datasets)  
+- Defines tools across multiple resource categories
+  - Rockfish API: Databases, Worker Sets, Workflows, Models, Projects, Datasets (22 tools, always available)
+  - Manta Service: Prompt Management, Data Manipulation, LLM Processing (10 tools, conditional)
+- Conditionally loads Manta tools only when `MANTA_BASE_URL` environment variable is set
 - Handles tool registration via `@server.list_tools()` decorator
-- Routes all tool calls through `@server.call_tool()` decorator to the Rockfish client
+- Routes tool calls through `@server.call_tool()` decorator:
+  - Tools prefixed with `manta_` route to `manta_client`
+  - All other tools route to `rockfish_client`
 - Manages server initialization and stdio communication with MCP protocol
-- Uses global `rockfish_client` instance initialized in `main()`
+- Uses global `rockfish_client` (always) and `manta_client` (conditional) instances initialized in `main()`
 - Requires `ROCKFISH_API_KEY` environment variable to function
 
-**Client (`client.py`)**: HTTP client wrapper that:
+**Client (`client.py`)**: HTTP client wrapper for Rockfish API that:
 - Handles Bearer token authentication for all API requests
 - Provides async HTTP requests to Rockfish API endpoints via httpx
 - Maps MCP tool names to specific HTTP endpoints and methods in `call_endpoint()`
 - Uses different HTTP methods (GET, POST, PUT, PATCH, DELETE) based on operation
 - Centralizes error handling with `raise_for_status()` and returns formatted responses
 
+**Manta Client (`manta_client.py`)**: HTTP client wrapper for Manta service that:
+- Handles Bearer token authentication (uses same `ROCKFISH_API_KEY`)
+- Provides async HTTP requests to Manta service endpoints via httpx
+- Manages required Manta headers (`X-Organization-ID`, `X-Project-ID`)
+- Maps Manta tool names to specific endpoints for:
+  - Prompt management (create, get, append, evaluate)
+  - Incident injection (spike, magnitude change, outage, ramp)
+  - LLM question processing
+- Centralizes error handling and returns formatted responses
+
 ### Tool Categories and API Mapping
+
+#### Rockfish API Endpoints
 The server exposes CRUD operations mapping to these endpoints:
 - **Databases**: `/database` endpoints (GET, POST, PUT, DELETE)
-- **Worker Sets**: `/worker-set` endpoints (GET, POST, DELETE - no update)  
+- **Worker Sets**: `/worker-set` endpoints (GET, POST, DELETE - no update)
 - **Workflows**: `/workflow` endpoints (GET, POST, PUT)
 - **Models**: `/models` endpoints (GET, POST, DELETE - note different path)
 - **Projects**: `/project` endpoints (GET, POST, PATCH)
 - **Datasets**: `/dataset` endpoints (GET, POST, PATCH, DELETE)
 
+#### Manta Service Endpoints (Optional)
+The Manta service provides dataset testing and pattern injection capabilities. These tools are only available when `MANTA_BASE_URL` is configured:
+- **Prompt Management**: `/prompts` endpoints (GET, POST, PATCH)
+  - Generate and manage test prompts for datasets
+  - Evaluate test case results
+- **Incident Injection**: Data manipulation endpoints
+  - `/instantaneous-spike-data`: Inject sudden spikes
+  - `/sustained-magnitude-change-data`: Apply sustained changes
+  - `/data-outage-data`: Create data gaps
+  - `/value-ramp-data`: Apply gradual changes
+  - `/incident-dataset-ids`: List all incident datasets
+- **LLM Processing**: `/customer-llm` endpoint
+  - Process natural language questions via SQL Agent
+
 ### Key Implementation Details
 
 - All API calls are asynchronous using `httpx.AsyncClient` with proper connection handling
-- The client uses a centralized `call_endpoint()` method with if/elif routing for tool dispatch
-- Server initialization creates a single global `RockfishClient` instance shared across all calls
+- Both clients use a centralized `call_endpoint()` method with if/elif routing for tool dispatch
+- Server initialization:
+  - Always creates a global `RockfishClient` instance
+  - Only creates `MantaClient` instance if `MANTA_BASE_URL` environment variable is set
+  - Manta tools are dynamically added to the tool list only when `manta_client` is initialized
+- Tool routing is handled by checking tool name prefix (`manta_` routes to Manta, others to Rockfish)
 - Tool schemas are defined inline using JSON Schema format directly in the server
 - Error handling returns `types.TextContent` objects for display to users
 - Each tool specifies required fields and optional parameters in its input schema
-- The client extracts IDs from arguments and constructs appropriate URL paths
+- The clients extract IDs and parameters from arguments and construct appropriate URL paths
+- Manta tools require `organization_id` and `project_id` in every request (passed as headers)
 
-The client abstracts the REST API complexity, while the server provides the MCP interface that AI assistants can use to interact with Rockfish resources programmatically.
+Both clients abstract REST API complexity, while the server provides a unified MCP interface that AI assistants can use to interact with Rockfish resources and Manta testing capabilities programmatically.
 
 ## API Reference
 
-For complete API documentation, see the OpenAPI specification at: https://docs.rockfish.ai/openapi.yaml
+For complete API documentation, see:
+- **Rockfish API**: https://docs.rockfish.ai/openapi.yaml
+- **Manta Service**: https://manta.sunset-beach.rockfish.ai/openapi.json

--- a/src/rockfish_mcp/manta_client.py
+++ b/src/rockfish_mcp/manta_client.py
@@ -1,0 +1,150 @@
+"""
+Manta service client for Rockfish MCP.
+
+Handles API calls to the Manta service for dataset pattern injection
+and test case generation.
+"""
+
+import os
+import httpx
+from typing import Any
+
+
+class MantaClient:
+    """Client for interacting with the Rockfish Manta API."""
+
+    def __init__(self, api_key: str, base_url: str = "https://manta.sunset-beach.rockfish.ai"):
+        """
+        Initialize the Manta client.
+
+        Args:
+            api_key: Rockfish API key for authentication
+            base_url: Base URL for the Manta API (default: https://manta.sunset-beach.rockfish.ai)
+        """
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json"
+        }
+
+    async def call_endpoint(self, tool_name: str, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+        """
+        Call a Manta API endpoint based on the tool name.
+
+        Args:
+            tool_name: Name of the MCP tool being called
+            arguments: Tool arguments containing request parameters
+
+        Returns:
+            API response data
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails
+        """
+        async with httpx.AsyncClient() as client:
+            # Extract common headers required by Manta API
+            extra_headers = {}
+            if "organization_id" in arguments:
+                extra_headers["X-Organization-ID"] = arguments["organization_id"]
+            if "project_id" in arguments:
+                extra_headers["X-Project-ID"] = arguments["project_id"]
+
+            headers = {**self.headers, **extra_headers}
+
+            # Route to appropriate endpoint based on tool name
+            if tool_name == "manta_get_prompts":
+                dataset_id = arguments["dataset_id"]
+                response = await client.get(
+                    f"{self.base_url}/prompts",
+                    headers=headers,
+                    params={"dataset_id": dataset_id}
+                )
+
+            elif tool_name == "manta_create_prompts":
+                response = await client.post(
+                    f"{self.base_url}/prompts",
+                    headers=headers,
+                    json={"dataset_id": arguments["dataset_id"]}
+                )
+
+            elif tool_name == "manta_append_prompts":
+                response = await client.patch(
+                    f"{self.base_url}/prompts",
+                    headers=headers,
+                    json={"dataset_id": arguments["dataset_id"]}
+                )
+
+            elif tool_name == "manta_evaluate_test_case":
+                response = await client.post(
+                    f"{self.base_url}/evaluate-test-case",
+                    headers=headers,
+                    json={
+                        "prompt": arguments["prompt"],
+                        "actual_result": arguments["actual_result"],
+                        "expected_result": arguments["expected_result"]
+                    }
+                )
+
+            elif tool_name == "manta_create_instantaneous_spike":
+                response = await client.post(
+                    f"{self.base_url}/instantaneous-spike-data",
+                    headers=headers,
+                    json={
+                        "dataset_id": arguments["dataset_id"],
+                        "incident_config": arguments["incident_config"]
+                    }
+                )
+
+            elif tool_name == "manta_create_sustained_magnitude_change":
+                response = await client.post(
+                    f"{self.base_url}/sustained-magnitude-change-data",
+                    headers=headers,
+                    json={
+                        "dataset_id": arguments["dataset_id"],
+                        "incident_config": arguments["incident_config"]
+                    }
+                )
+
+            elif tool_name == "manta_create_data_outage":
+                response = await client.post(
+                    f"{self.base_url}/data-outage-data",
+                    headers=headers,
+                    json={
+                        "dataset_id": arguments["dataset_id"],
+                        "incident_config": arguments["incident_config"]
+                    }
+                )
+
+            elif tool_name == "manta_create_value_ramp":
+                response = await client.post(
+                    f"{self.base_url}/value-ramp-data",
+                    headers=headers,
+                    json={
+                        "dataset_id": arguments["dataset_id"],
+                        "incident_config": arguments["incident_config"]
+                    }
+                )
+
+            elif tool_name == "manta_get_incident_dataset_ids":
+                response = await client.post(
+                    f"{self.base_url}/incident-dataset-ids",
+                    headers=headers,
+                    json={"dataset_id": arguments["dataset_id"]}
+                )
+
+            elif tool_name == "manta_process_llm_questions":
+                response = await client.post(
+                    f"{self.base_url}/customer-llm",
+                    headers=headers,
+                    json={
+                        "dataset_id": arguments["dataset_id"],
+                        "questions": arguments["questions"]
+                    }
+                )
+
+            else:
+                raise ValueError(f"Unknown Manta tool: {tool_name}")
+
+            response.raise_for_status()
+            return response.json()


### PR DESCRIPTION
## Summary
This PR integrates the Manta dataset testing service into the MCP server, providing AI assistants with advanced testing and pattern injection capabilities for datasets.

### New Features
- **MantaClient**: New HTTP client for Manta service API communication
- **Conditional Tool Loading**: Manta tools only appear when `MANTA_BASE_URL` environment variable is set
- **10 New Manta Tools** across three categories:
  - **Prompt Management**: Generate, retrieve, append, and evaluate test prompts for datasets
  - **Incident Injection**: Inject data patterns including spikes, outages, ramps, and magnitude changes
  - **LLM Processing**: Process natural language questions using SQL Agent functionality

### Changes Made
- Added [manta_client.py](src/rockfish_mcp/manta_client.py): New HTTP client for Manta service operations
- Updated [server.py](src/rockfish_mcp/server.py): Conditional loading and routing of Manta tools
- Updated [.env.example](.env.example): Added MANTA_BASE_URL configuration with documentation
- Updated [CLAUDE.md](CLAUDE.md): Comprehensive documentation of new architecture and capabilities

### Implementation Details
- Manta tools use `manta_` prefix for routing to the appropriate client
- All Manta operations require `organization_id` and `project_id` parameters
- Maintains full backward compatibility (works without Manta configuration)
- Uses same authentication token (`ROCKFISH_API_KEY`) as Rockfish API
- Tool routing logic checks prefix and dispatches to correct client

### Testing Checklist
- [x] Verify MCP server starts without MANTA_BASE_URL set
- [x] Verify only 22 Rockfish tools are listed when Manta is not configured
- [x] Verify MCP server starts with MANTA_BASE_URL set
- [x] Verify all 32 tools (22 Rockfish + 10 Manta) are listed when configured
- [x] Test Rockfish tools continue to work as expected
- [x] Test at least one Manta prompt management tool
- [x] Test at least one Manta incident injection tool
- [x] Test Manta LLM question processing tool
- [x] Verify error handling when Manta service is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)