### PR TITLE
Remove query_dataset tool from MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ src/rockfish_mcp/
 
 **Server (`server.py`)**: The main MCP server that:
 - Defines tools across multiple resource categories
-  - Rockfish API: Databases, Worker Sets, Workflows, Models, Projects, Datasets (22 tools, always available)
+  - Rockfish API: Databases, Worker Sets, Workflows, Models, Projects, Datasets (21 tools, always available)
   - Manta Service: Prompt Management, Data Manipulation, LLM Processing (10 tools, conditional)
   - SDK Tools: Synthetic Data Generation workflow tools (9 tools, always available)
 - Conditionally loads Manta tools only when `MANTA_API_URL` environment variable is set

--- a/src/rockfish_mcp/client.py
+++ b/src/rockfish_mcp/client.py
@@ -201,27 +201,5 @@ class RockfishClient:
                 response.raise_for_status()
                 return {"result": response.text}
 
-        elif tool_name == "query_dataset":
-            dataset_id = arguments["id"]
-            query = arguments["query"]
-            project_id = arguments.get("project_id")
-
-            # Prepare headers for dataset query request
-            query_headers = {
-                "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "text/plain",
-            }
-            if project_id:
-                query_headers["X-Project-ID"] = project_id
-
-            # Make dataset query request with text/plain content
-            url = f"{self.api_url}/dataset/{dataset_id}/query"
-            async with httpx.AsyncClient() as client:
-                response = await client.request(
-                    method="POST", url=url, headers=query_headers, content=query
-                )
-                response.raise_for_status()
-                return {"result": response.text}
-
         else:
             raise ValueError(f"Unknown tool: {tool_name}")

--- a/src/rockfish_mcp/server.py
+++ b/src/rockfish_mcp/server.py
@@ -432,25 +432,6 @@ async def handle_list_tools() -> List[types.Tool]:
                 "required": ["query"],
             },
         ),
-        types.Tool(
-            name="query_dataset",
-            description="Execute a query against a specific dataset and return results in CSV format",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Dataset ID to query against",
-                    },
-                    "query": {"type": "string", "description": "The query to execute"},
-                    "project_id": {
-                        "type": "string",
-                        "description": "Optional project ID to execute the query in",
-                    },
-                },
-                "required": ["id", "query"],
-            },
-        ),
     ]
 
     # Add Manta tools only if Manta client is initialized
@@ -1117,7 +1098,9 @@ async def main():
     # Initialize Rockfish client
     api_key = os.getenv("ROCKFISH_API_KEY")
     # Support both new API_URL and legacy BASE_URL variable names for backwards compatibility
-    api_url = os.getenv("ROCKFISH_API_URL") or os.getenv("ROCKFISH_BASE_URL", "https://api.rockfish.ai")
+    api_url = os.getenv("ROCKFISH_API_URL") or os.getenv(
+        "ROCKFISH_BASE_URL", "https://api.rockfish.ai"
+    )
     organization_id = os.getenv("ROCKFISH_ORGANIZATION_ID", None)
     project_id = os.getenv("ROCKFISH_PROJECT_ID", None)
 


### PR DESCRIPTION
## Summary
- Removes the `query_dataset` tool from both server and client implementations
- Updates documentation to reflect the reduced tool count (22 → 21 Rockfish API tools)

## Rationale
The `query_dataset` tool is redundant as the `execute_query` tool provides the same functionality and works better with LLMs. Specifically, `query_dataset` requires the table name to be "my_table", which is unintuitive for LLMs. In contrast, `execute_query` uses the dataset ID as the table name, which works out of the box with LLM interactions.

## Changes
- Removed `query_dataset` tool definition from [server.py](src/rockfish_mcp/server.py#L435-L453)
- Removed `query_dataset` implementation from [client.py](src/rockfish_mcp/client.py#L204-L224)
- Updated tool count in [CLAUDE.md](CLAUDE.md#L55)

## Test plan
- Verify the MCP server starts without errors
- Confirm `execute_query` tool continues to function correctly
- Ensure no references to `query_dataset` remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)