### PR TITLE
Add comprehensive test coverage for list_ tools

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,109 @@
+"""
+Shared pytest fixtures for Rockfish MCP tests.
+
+This module provides common fixtures used across multiple test files
+to avoid duplication and ensure consistent test setup.
+"""
+
+import os
+
+import pytest
+import pytest_asyncio
+from dotenv import load_dotenv
+
+import rockfish_mcp.server as server_module
+from rockfish_mcp.client import RockfishClient
+from rockfish_mcp.manta_client import MantaClient
+from rockfish_mcp.sdk_client import RockfishSDKClient
+
+# Load environment variables
+load_dotenv()
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def initialize_server_clients():
+    """
+    Initialize the server's global clients before running tests.
+
+    This fixture runs once per test session and initializes the global
+    rockfish_client, manta_client, and sdk_client in the server module
+    so that handle_call_tool() can use them.
+    """
+    api_key = os.getenv("ROCKFISH_API_KEY")
+    api_url = os.getenv("ROCKFISH_API_URL", "https://api.rockfish.ai")
+    manta_api_url = os.getenv("MANTA_API_URL")
+    organization_id = os.getenv("ROCKFISH_ORGANIZATION_ID")
+    project_id = os.getenv("ROCKFISH_PROJECT_ID")
+
+    if not api_key:
+        pytest.skip("ROCKFISH_API_KEY not set")
+
+    # Initialize global clients in the server module
+    server_module.rockfish_client = RockfishClient(
+        api_key=api_key,
+        api_url=api_url,
+        organization_id=organization_id,
+        project_id=project_id,
+    )
+
+    server_module.sdk_client = RockfishSDKClient(
+        API_KEY=api_key,
+        API_URL=api_url,
+        ORGANIZATION_ID=organization_id,
+        PROJECT_ID=project_id,
+    )
+
+    # Only initialize Manta client if URL is configured
+    if manta_api_url:
+        server_module.manta_client = MantaClient(api_key=api_key, api_url=manta_api_url)
+
+    yield
+
+    # Cleanup
+    if server_module.sdk_client:
+        await server_module.sdk_client.close()
+
+
+@pytest.fixture(scope="session")
+def api_key():
+    """Get API key from environment."""
+    key = os.getenv("ROCKFISH_API_KEY")
+    if not key:
+        pytest.skip("ROCKFISH_API_KEY not set")
+    return key
+
+
+@pytest.fixture(scope="session")
+def organization_id():
+    """Get organization ID from environment."""
+    org_id = os.getenv("ROCKFISH_ORGANIZATION_ID")
+    if not org_id:
+        pytest.skip("ROCKFISH_ORGANIZATION_ID not set")
+    return org_id
+
+
+@pytest.fixture(scope="session")
+def project_id():
+    """Get project ID from environment."""
+    proj_id = os.getenv("ROCKFISH_PROJECT_ID")
+    if not proj_id:
+        pytest.skip("ROCKFISH_PROJECT_ID not set")
+    return proj_id
+
+
+@pytest.fixture(scope="session")
+def dataset_id():
+    """Get dataset ID for testing from environment."""
+    ds_id = os.getenv("INCIDENT_CREATION_TEST_DATASET")
+    if not ds_id:
+        pytest.skip("INCIDENT_CREATION_TEST_DATASET not set")
+    return ds_id
+
+
+@pytest.fixture(scope="session")
+def manta_api_url():
+    """Get Manta API URL from environment."""
+    url = os.getenv("MANTA_API_URL")
+    if not url:
+        pytest.skip("MANTA_API_URL not set")
+    return url

--- a/tests/test_create_incident_dataset.py
+++ b/tests/test_create_incident_dataset.py
@@ -7,69 +7,14 @@ incident configuration defined in the file.
 
 import ast
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
-import pytest_asyncio
 import yaml
-from dotenv import load_dotenv
 from mcp import types
 
-import rockfish_mcp.server as server_module
-from rockfish_mcp.client import RockfishClient
-from rockfish_mcp.manta_client import MantaClient
-from rockfish_mcp.sdk_client import RockfishSDKClient
 from rockfish_mcp.server import handle_call_tool
-
-# Load environment variables
-load_dotenv()
-
-
-@pytest_asyncio.fixture(scope="session", autouse=True)
-async def initialize_server_clients():
-    """
-    Initialize the server's global clients before running tests.
-
-    This fixture runs once per test session and initializes the global
-    rockfish_client, manta_client, and sdk_client in the server module
-    so that handle_call_tool() can use them.
-    """
-    api_key = os.getenv("ROCKFISH_API_KEY")
-    api_url = os.getenv("ROCKFISH_API_URL", "https://api.rockfish.ai")
-    manta_api_url = os.getenv("MANTA_API_URL")
-    organization_id = os.getenv("ROCKFISH_ORGANIZATION_ID")
-    project_id = os.getenv("ROCKFISH_PROJECT_ID")
-
-    if not api_key:
-        pytest.skip("ROCKFISH_API_KEY not set")
-
-    if not manta_api_url:
-        pytest.skip("MANTA_API_URL not set")
-
-    # Initialize global clients in the server module
-    server_module.rockfish_client = RockfishClient(
-        api_key=api_key,
-        api_url=api_url,
-        organization_id=organization_id,
-        project_id=project_id,
-    )
-
-    server_module.sdk_client = RockfishSDKClient(
-        API_KEY=api_key,
-        API_URL=api_url,
-        ORGANIZATION_ID=organization_id,
-        PROJECT_ID=project_id,
-    )
-
-    server_module.manta_client = MantaClient(api_key=api_key, api_url=manta_api_url)
-
-    yield
-
-    # Cleanup
-    if server_module.sdk_client:
-        await server_module.sdk_client.close()
 
 
 def load_incident_configs() -> List[Dict[str, Any]]:
@@ -99,30 +44,6 @@ incident_configs = load_incident_configs()
 
 class TestCreateIncidentDataset:
     """Test class for create_incident_dataset tool."""
-
-    @pytest.fixture(scope="class")
-    def organization_id(self):
-        """Get organization ID from environment."""
-        org_id = os.getenv("ROCKFISH_ORGANIZATION_ID")
-        if not org_id:
-            pytest.skip("ROCKFISH_ORGANIZATION_ID not set")
-        return org_id
-
-    @pytest.fixture(scope="class")
-    def project_id(self):
-        """Get project ID from environment."""
-        proj_id = os.getenv("ROCKFISH_PROJECT_ID")
-        if not proj_id:
-            pytest.skip("ROCKFISH_PROJECT_ID not set")
-        return proj_id
-
-    @pytest.fixture(scope="class")
-    def dataset_id(self):
-        """Get dataset ID for testing from environment."""
-        ds_id = os.getenv("INCIDENT_CREATION_TEST_DATASET")
-        if not ds_id:
-            pytest.skip("INCIDENT_CREATION_TEST_DATASET not set")
-        return ds_id
 
     @pytest.mark.parametrize(
         "incident",

--- a/tests/test_list_resources.py
+++ b/tests/test_list_resources.py
@@ -1,0 +1,289 @@
+"""
+Tests for all list_ tools in the Rockfish MCP server.
+
+This test module exercises all tools starting with "list_" and verifies
+that they return non-empty lists of resources.
+"""
+
+import ast
+import json
+
+import pytest
+from mcp import types
+
+from rockfish_mcp.server import handle_call_tool
+
+
+class TestListResources:
+    """Test class for list_ tools."""
+
+    @pytest.mark.asyncio
+    async def test_list_databases(self, organization_id: str, project_id: str):
+        """Test listing databases returns non-empty list."""
+        arguments = {
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+
+        result = await handle_call_tool("list_databases", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            databases = json.loads(result_text)
+        except json.JSONDecodeError:
+            databases = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(databases, list), "Result should be a list"
+        # Note: We don't assert non-empty as the list might be empty if no databases exist
+
+    @pytest.mark.asyncio
+    async def test_list_worker_sets(self, organization_id: str, project_id: str):
+        """Test listing worker sets returns a list."""
+        arguments = {
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+
+        result = await handle_call_tool("list_worker_sets", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            worker_sets = json.loads(result_text)
+        except json.JSONDecodeError:
+            worker_sets = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(worker_sets, list), "Result should be a list"
+
+    @pytest.mark.asyncio
+    async def test_list_available_actions(self):
+        """Test listing available actions returns a dict with actions list."""
+        arguments = {}
+
+        result = await handle_call_tool("list_available_actions", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            response = json.loads(result_text)
+        except json.JSONDecodeError:
+            response = ast.literal_eval(result_text)
+
+        # Verify we got a dict with 'actions' key
+        assert isinstance(response, dict), "Result should be a dict"
+        assert "actions" in response, "Result should contain 'actions' key"
+        actions = response["actions"]
+        assert isinstance(actions, list), "actions should be a list"
+        # Available actions should not be empty
+        assert len(actions) > 0, "Available actions list should not be empty"
+
+    @pytest.mark.asyncio
+    async def test_list_workflows(self, organization_id: str, project_id: str):
+        """Test listing workflows returns a list."""
+        arguments = {
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+
+        result = await handle_call_tool("list_workflows", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            workflows = json.loads(result_text)
+        except json.JSONDecodeError:
+            workflows = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(workflows, list), "Result should be a list"
+
+    @pytest.mark.asyncio
+    async def test_list_models(self, organization_id: str, project_id: str):
+        """Test listing models returns a list."""
+        arguments = {
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+
+        result = await handle_call_tool("list_models", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            models = json.loads(result_text)
+        except json.JSONDecodeError:
+            models = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(models, list), "Result should be a list"
+
+    @pytest.mark.asyncio
+    async def test_list_organizations(self):
+        """Test listing organizations returns non-empty list."""
+        arguments = {}
+
+        result = await handle_call_tool("list_organizations", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            organizations = json.loads(result_text)
+        except json.JSONDecodeError:
+            organizations = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(organizations, list), "Result should be a list"
+        # Should have at least one organization
+        assert len(organizations) > 0, "Organizations list should not be empty"
+
+    @pytest.mark.asyncio
+    async def test_list_projects(self, organization_id: str):
+        """Test listing projects returns non-empty list."""
+        arguments = {
+            "organization_id": organization_id,
+        }
+
+        result = await handle_call_tool("list_projects", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            projects = json.loads(result_text)
+        except json.JSONDecodeError:
+            projects = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(projects, list), "Result should be a list"
+        # Should have at least one project
+        assert len(projects) > 0, "Projects list should not be empty"
+
+    @pytest.mark.asyncio
+    async def test_list_datasets(self, organization_id: str, project_id: str):
+        """Test listing datasets returns a list."""
+        arguments = {
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+
+        result = await handle_call_tool("list_datasets", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            datasets = json.loads(result_text)
+        except json.JSONDecodeError:
+            datasets = ast.literal_eval(result_text)
+
+        # Verify we got a list back
+        assert isinstance(datasets, list), "Result should be a list"
+
+    @pytest.mark.asyncio
+    async def test_list_incident_datasets(
+        self, organization_id: str, project_id: str, dataset_id: str, manta_api_url: str
+    ):
+        """Test listing incident datasets returns a dict with dataset_ids list."""
+        # This test requires Manta API to be configured
+        arguments = {
+            "dataset_id": dataset_id,
+            "organization_id": organization_id,
+            "project_id": project_id,
+        }
+
+        result = await handle_call_tool("list_incident_datasets", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            response = json.loads(result_text)
+        except json.JSONDecodeError:
+            response = ast.literal_eval(result_text)
+
+        # Verify we got a dict with 'dataset_ids' key
+        assert isinstance(response, dict), "Result should be a dict"
+        assert "dataset_ids" in response, "Result should contain 'dataset_ids' key"
+        dataset_ids = response["dataset_ids"]
+        assert isinstance(dataset_ids, list), "dataset_ids should be a list"


### PR DESCRIPTION
## Summary
- Refactored test fixtures into shared `conftest.py` to avoid duplication
- Created comprehensive tests for all 9 `list_` tools in the MCP server
- All tests verify proper response structures and API contract

## Changes
### New Files
- **[tests/conftest.py](tests/conftest.py)**: Shared pytest fixtures for all tests
  - Session-level fixtures for `organization_id`, `project_id`, `dataset_id`, `api_key`, `manta_api_url`
  - Automatic initialization of server clients (`rockfish_client`, `sdk_client`, `manta_client`)

- **[tests/test_list_resources.py](tests/test_list_resources.py)**: Tests for all 9 list_ tools
  - `test_list_databases` - Rockfish API
  - `test_list_worker_sets` - Rockfish API
  - `test_list_available_actions` - Rockfish API (returns dict with 'actions' key)
  - `test_list_workflows` - Rockfish API
  - `test_list_models` - Rockfish API
  - `test_list_organizations` - Rockfish API (asserts non-empty)
  - `test_list_projects` - Rockfish API (asserts non-empty)
  - `test_list_datasets` - Rockfish API
  - `test_list_incident_datasets` - Manta API (returns dict with 'dataset_ids' key)

### Modified Files
- **[tests/test_create_incident_dataset.py](tests/test_create_incident_dataset.py)**: Refactored to use shared fixtures
  - Removed duplicate fixture definitions (organization_id, project_id, dataset_id)
  - Removed duplicate client initialization code
  - Now uses shared fixtures from conftest.py

## Test Results
All 15 tests pass successfully:
- 6 tests from test_create_incident_dataset.py (4 parametrized + 2 error cases)
- 9 tests from test_list_resources.py (all list_ tools)

## Test Plan
✅ Ran `pytest tests/ -v` - all 15 tests pass
✅ Verified fixtures are properly shared between test files
✅ Confirmed no duplication of fixture code

Resolves #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)