### PR TITLE
Add list_worker_groups tool and improve .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Environment variables
-.env
-.env.local
-.env.*.local
+.env*
+!.env.example
 
 # Python
 __pycache__/

--- a/src/rockfish_mcp/client.py
+++ b/src/rockfish_mcp/client.py
@@ -85,6 +85,10 @@ class RockfishClient:
             ws_id = arguments["id"]
             return await self._request("GET", f"/worker-set/{ws_id}/actions")
 
+        # Worker Group endpoints
+        elif tool_name == "list_worker_groups":
+            return await self._request("GET", "/worker-group")
+
         elif tool_name == "list_available_actions":
             worker_groups = await self._request("GET", "/worker-group")
 

--- a/src/rockfish_mcp/manta_client.py
+++ b/src/rockfish_mcp/manta_client.py
@@ -14,9 +14,7 @@ import httpx
 class MantaClient:
     """Client for interacting with the Rockfish Manta API."""
 
-    def __init__(
-        self, api_key: str, api_url: str = "https://manta.rockfish.ai"
-    ):
+    def __init__(self, api_key: str, api_url: str = "https://manta.rockfish.ai"):
         """
         Initialize the Manta client.
 

--- a/src/rockfish_mcp/server.py
+++ b/src/rockfish_mcp/server.py
@@ -140,6 +140,12 @@ async def handle_list_tools() -> List[types.Tool]:
                 "required": ["id"],
             },
         ),
+        # Worker Group tools
+        types.Tool(
+            name="list_worker_groups",
+            description="List all worker groups",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
         # Worker tools
         types.Tool(
             name="list_available_actions",
@@ -425,7 +431,7 @@ async def handle_list_tools() -> List[types.Tool]:
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "The SQL query to execute. REQUIRED SQL SYNTAX: Use dataset ID wrapped in double quotes as table name (e.g., \"rWBroVVFla7I0Fv9nBZXh\") and wrap column names in backticks (e.g., `column_name`). Example: SELECT `timestamp`, `value` FROM \"rWBroVVFla7I0Fv9nBZXh\" WHERE `status` = 'active'"
+                        "description": 'The SQL query to execute. REQUIRED SQL SYNTAX: Use dataset ID wrapped in double quotes as table name (e.g., "rWBroVVFla7I0Fv9nBZXh") and wrap column names in backticks (e.g., `column_name`). Example: SELECT `timestamp`, `value` FROM "rWBroVVFla7I0Fv9nBZXh" WHERE `status` = \'active\'',
                     },
                     "project_id": {
                         "type": "string",
@@ -494,31 +500,39 @@ IMPORTANT: The incident_config object schema MUST match the selected incident_ty
                                                 "type": "object",
                                                 "properties": {
                                                     "column_name": {"type": "string"},
-                                                    "value": {"description": "Any value type"}
+                                                    "value": {
+                                                        "description": "Any value type"
+                                                    },
                                                 },
-                                                "required": ["column_name", "value"]
+                                                "required": ["column_name", "value"],
                                             },
-                                            "description": "List of metadata predicates to identify impacted rows"
+                                            "description": "List of metadata predicates to identify impacted rows",
                                         },
                                         "impacted_measurement": {
                                             "type": "string",
-                                            "description": "Name of the measurement column to inject spike into"
+                                            "description": "Name of the measurement column to inject spike into",
                                         },
                                         "absolute_magnitude": {
                                             "type": ["number", "integer"],
-                                            "description": "Absolute spike value to inject"
+                                            "description": "Absolute spike value to inject",
                                         },
                                         "timestamp_column": {
                                             "type": "string",
-                                            "description": "Name of the timestamp column"
+                                            "description": "Name of the timestamp column",
                                         },
                                         "timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "Timestamp when spike occurs (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
-                                        }
+                                            "description": "Timestamp when spike occurs (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
+                                        },
                                     },
-                                    "required": ["impacted_metadata_predicate", "impacted_measurement", "absolute_magnitude", "timestamp_column", "timestamp"]
+                                    "required": [
+                                        "impacted_metadata_predicate",
+                                        "impacted_measurement",
+                                        "absolute_magnitude",
+                                        "timestamp_column",
+                                        "timestamp",
+                                    ],
                                 },
                                 {
                                     "title": "SustainedMagnitudeChangeIncidentConfig (for incident_type='sustained-magnitude-change-data')",
@@ -530,36 +544,45 @@ IMPORTANT: The incident_config object schema MUST match the selected incident_ty
                                                 "type": "object",
                                                 "properties": {
                                                     "column_name": {"type": "string"},
-                                                    "value": {"description": "Any value type"}
+                                                    "value": {
+                                                        "description": "Any value type"
+                                                    },
                                                 },
-                                                "required": ["column_name", "value"]
+                                                "required": ["column_name", "value"],
                                             },
-                                            "description": "List of metadata predicates to identify impacted rows"
+                                            "description": "List of metadata predicates to identify impacted rows",
                                         },
                                         "impacted_measurement": {
                                             "type": "string",
-                                            "description": "Name of the measurement column to modify"
+                                            "description": "Name of the measurement column to modify",
                                         },
                                         "delta_magnitude": {
                                             "type": ["number", "integer"],
-                                            "description": "Delta value to add to measurements during incident period"
+                                            "description": "Delta value to add to measurements during incident period",
                                         },
                                         "timestamp_column": {
                                             "type": "string",
-                                            "description": "Name of the timestamp column"
+                                            "description": "Name of the timestamp column",
                                         },
                                         "start_timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "Start timestamp of sustained change (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
+                                            "description": "Start timestamp of sustained change (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
                                         },
                                         "end_timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "End timestamp of sustained change (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
-                                        }
+                                            "description": "End timestamp of sustained change (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
+                                        },
                                     },
-                                    "required": ["impacted_metadata_predicate", "impacted_measurement", "delta_magnitude", "timestamp_column", "start_timestamp", "end_timestamp"]
+                                    "required": [
+                                        "impacted_metadata_predicate",
+                                        "impacted_measurement",
+                                        "delta_magnitude",
+                                        "timestamp_column",
+                                        "start_timestamp",
+                                        "end_timestamp",
+                                    ],
                                 },
                                 {
                                     "title": "DataOutageIncidentConfig (for incident_type='data-outage-data')",
@@ -571,36 +594,45 @@ IMPORTANT: The incident_config object schema MUST match the selected incident_ty
                                                 "type": "object",
                                                 "properties": {
                                                     "column_name": {"type": "string"},
-                                                    "value": {"description": "Any value type"}
+                                                    "value": {
+                                                        "description": "Any value type"
+                                                    },
                                                 },
-                                                "required": ["column_name", "value"]
+                                                "required": ["column_name", "value"],
                                             },
-                                            "description": "List of metadata predicates to identify impacted rows"
+                                            "description": "List of metadata predicates to identify impacted rows",
                                         },
                                         "impacted_measurement": {
                                             "type": "string",
-                                            "description": "Name of the measurement column to set to outage value"
+                                            "description": "Name of the measurement column to set to outage value",
                                         },
                                         "absolute_magnitude": {
                                             "type": ["number", "integer"],
-                                            "description": "Value to set during outage (typically 0 or null-equivalent)"
+                                            "description": "Value to set during outage (typically 0 or null-equivalent)",
                                         },
                                         "timestamp_column": {
                                             "type": "string",
-                                            "description": "Name of the timestamp column"
+                                            "description": "Name of the timestamp column",
                                         },
                                         "start_timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "Start timestamp of outage (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
+                                            "description": "Start timestamp of outage (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
                                         },
                                         "end_timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "End timestamp of outage (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
-                                        }
+                                            "description": "End timestamp of outage (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
+                                        },
                                     },
-                                    "required": ["impacted_metadata_predicate", "impacted_measurement", "absolute_magnitude", "timestamp_column", "start_timestamp", "end_timestamp"]
+                                    "required": [
+                                        "impacted_metadata_predicate",
+                                        "impacted_measurement",
+                                        "absolute_magnitude",
+                                        "timestamp_column",
+                                        "start_timestamp",
+                                        "end_timestamp",
+                                    ],
                                 },
                                 {
                                     "title": "ValueRampIncidentConfig (for incident_type='value-ramp-data')",
@@ -612,42 +644,52 @@ IMPORTANT: The incident_config object schema MUST match the selected incident_ty
                                                 "type": "object",
                                                 "properties": {
                                                     "column_name": {"type": "string"},
-                                                    "value": {"description": "Any value type"}
+                                                    "value": {
+                                                        "description": "Any value type"
+                                                    },
                                                 },
-                                                "required": ["column_name", "value"]
+                                                "required": ["column_name", "value"],
                                             },
-                                            "description": "List of metadata predicates to identify impacted rows"
+                                            "description": "List of metadata predicates to identify impacted rows",
                                         },
                                         "impacted_measurement": {
                                             "type": "string",
-                                            "description": "Name of the measurement column to ramp"
+                                            "description": "Name of the measurement column to ramp",
                                         },
                                         "end_absolute_magnitude": {
                                             "type": ["number", "integer"],
-                                            "description": "Final absolute value at end of ramp"
+                                            "description": "Final absolute value at end of ramp",
                                         },
                                         "slope": {
                                             "type": ["number", "integer"],
-                                            "description": "Rate of change per time unit"
+                                            "description": "Rate of change per time unit",
                                         },
                                         "timestamp_column": {
                                             "type": "string",
-                                            "description": "Name of the timestamp column"
+                                            "description": "Name of the timestamp column",
                                         },
                                         "start_timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "Start timestamp of ramp (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
+                                            "description": "Start timestamp of ramp (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
                                         },
                                         "end_timestamp": {
                                             "type": "string",
                                             "format": "date-time",
-                                            "description": "End timestamp of ramp (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')"
-                                        }
+                                            "description": "End timestamp of ramp (ISO 8601 format, e.g., '2024-01-15T10:30:00Z' or '2024-01-15T10:30:00-05:00')",
+                                        },
                                     },
-                                    "required": ["impacted_metadata_predicate", "impacted_measurement", "end_absolute_magnitude", "slope", "timestamp_column", "start_timestamp", "end_timestamp"]
-                                }
-                            ]
+                                    "required": [
+                                        "impacted_metadata_predicate",
+                                        "impacted_measurement",
+                                        "end_absolute_magnitude",
+                                        "slope",
+                                        "timestamp_column",
+                                        "start_timestamp",
+                                        "end_timestamp",
+                                    ],
+                                },
+                            ],
                         },
                         "organization_id": {
                             "type": "string",

--- a/tests/test_list_resources.py
+++ b/tests/test_list_resources.py
@@ -150,6 +150,37 @@ class TestListResources:
             )
 
     @pytest.mark.asyncio
+    async def test_list_worker_groups(self):
+        """Test listing worker groups returns a dict with groups list."""
+        arguments = {}
+
+        result = await handle_call_tool("list_worker_groups", arguments)
+
+        assert result is not None, "Result should not be None"
+        assert len(result) > 0, "Result should contain content"
+
+        # Extract and parse the response
+        first_content = result[0]
+        assert isinstance(
+            first_content, types.TextContent
+        ), "Result should be TextContent"
+        result_text = first_content.text
+
+        # Parse the response
+        try:
+            response = json.loads(result_text)
+        except json.JSONDecodeError:
+            response = ast.literal_eval(result_text)
+
+        # Verify we got a dict with 'groups' key
+        assert isinstance(response, dict), "Result should be a dict"
+        assert "groups" in response, "Result should contain 'groups' key"
+        groups = response["groups"]
+        assert isinstance(groups, list), "groups should be a list"
+        # Worker groups should not be empty
+        assert len(groups) > 0, "Worker groups list should not be empty"
+
+    @pytest.mark.asyncio
     async def test_list_available_actions(self):
         """Test listing available actions returns a dict with actions list."""
         arguments = {}


### PR DESCRIPTION
## Summary
- Add `list_worker_groups` tool to retrieve all worker groups from the Rockfish API
- Improve `.gitignore` patterns to use `.env*` with `!.env.example` exception for better environment file handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)