### PR TITLE
Fix value-ramp-data test configuration field names

### DIFF
--- a/tests/incidents.yaml
+++ b/tests/incidents.yaml
@@ -32,8 +32,8 @@
 
 - type: value-ramp-data
   configuration:
-    end_absolute_magnitude: 50
-    slope: 0.5
+    start_magnitude: 0
+    end_magnitude: 50
     impacted_measurement: "comments"
     impacted_metadata_predicate:
       - column_name: "creatorEmail"


### PR DESCRIPTION
## Summary
- Fix incorrect field names in `value-ramp-data` test configuration in `tests/incidents.yaml`
- Change `end_absolute_magnitude` to `end_magnitude`, added `start_magnitude`, and removed `slope` to match the Manta API schema
- Resolves 422 validation errors when running incident injection tests

## Test plan
- [x] Verified fix by running `pytest --env=.env.staging.local` - all 16 tests now pass